### PR TITLE
Colorize cracked hashes for non windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -352,8 +352,16 @@ static void main_cracker_hash_cracked (MAYBE_UNUSED hashcat_ctx_t *hashcat_ctx, 
     if (outfile_ctx->filename == NULL) if (user_options->quiet == false) clear_prompt (hashcat_ctx);
   }
 
+  #if defined (_WIN)
   fwrite (buf, len,          1, stdout);
   fwrite (EOL, strlen (EOL), 1, stdout);
+  #else
+  // make cracked hash output in cyan
+  fputs("\033[36m", stdout);
+  fwrite (buf, len,          1, stdout);
+  fwrite("\033[0m", 4, 1, stdout);
+  fwrite (EOL, strlen (EOL), 1, stdout);
+  #endif
 
   if ((user_options_extra->wordlist_mode == WL_MODE_FILE) || (user_options_extra->wordlist_mode == WL_MODE_MASK))
   {


### PR DESCRIPTION
Make cracked hashes cyan in stdout, if program compiled on non _WIN os

partially solves:
- https://github.com/hashcat/hashcat/issues/3158 
- https://github.com/hashcat/hashcat/issues/3515